### PR TITLE
Add the option to view the sale price of an entire stack

### DIFF
--- a/ConfigUI.cs
+++ b/ConfigUI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ImGuiNET;
 
 namespace PriceInsight; 
@@ -50,6 +50,14 @@ class ConfigUI : IDisposable {
             }
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("The current world you're on will be considered your \"home world\".\nUseful if you're datacenter travelling and want to see prices there.");
+
+            configValue = conf.ShowStackSalePrice;
+            if (ImGui.Checkbox("Show stack sale price", ref configValue)) {
+                conf.ShowStackSalePrice = configValue;
+                conf.Save();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Show the price of the hovered stack if sold at the given unit price.");
 
             ImGui.Separator();
             ImGui.PushID(0);

--- a/ConfigUI.cs
+++ b/ConfigUI.cs
@@ -51,14 +51,6 @@ class ConfigUI : IDisposable {
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("The current world you're on will be considered your \"home world\".\nUseful if you're datacenter travelling and want to see prices there.");
 
-            configValue = conf.ShowStackSalePrice;
-            if (ImGui.Checkbox("Show stack sale price", ref configValue)) {
-                conf.ShowStackSalePrice = configValue;
-                conf.Save();
-            }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Show the price of the hovered stack if sold at the given unit price.");
-
             ImGui.Separator();
             ImGui.PushID(0);
             
@@ -130,6 +122,14 @@ class ConfigUI : IDisposable {
             }
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("Show the average sale price based on the last 20 purchases.");
+            
+            configValue = conf.ShowStackSalePrice;
+            if (ImGui.Checkbox("Show stack sale price", ref configValue)) {
+                conf.ShowStackSalePrice = configValue;
+                conf.Save();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Show the price of the hovered stack if sold at the given unit price.");
         }
 
         ImGui.End();

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
 
@@ -13,6 +13,8 @@ public class Configuration : IPluginConfiguration {
     public bool ShowDatacenter { get; set; } = true;
 
     public bool ShowWorld { get; set; } = true;
+
+    public bool ShowStackSalePrice { get; set; } = false;
 
     public bool ShowMostRecentPurchase { get; set; } = false;
 

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -11,13 +11,19 @@ public class Hooks : IDisposable {
         
     private unsafe delegate void* AddonOnUpdate(AtkUnitBase* atkUnitBase, NumberArrayData** nums, StringArrayData** strings);
 
+    private unsafe delegate bool AgentItemDetailOnItemHovered(void* a1, void* a2, void* a3, void* a4, uint a5, uint a6, int* a7);
+
     [Signature("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 20 4C 8B AA", DetourName = nameof(ItemDetailOnUpdateDetour))]
     private readonly Hook<AddonOnUpdate> itemDetailOnUpdateHook = null!;
+
+    [Signature("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 40 8B 81", DetourName = nameof(AgentItemDetailOnItemHoveredDetour))]
+    private readonly Hook<AgentItemDetailOnItemHovered> agentItemDetailOnItemHovered = null!;
 
     public Hooks(PriceInsightPlugin plugin) {
         this.plugin = plugin;
         SignatureHelper.Initialise(this);
         itemDetailOnUpdateHook.Enable();
+        agentItemDetailOnItemHovered.Enable();
     }
 
     private unsafe void* ItemDetailOnUpdateDetour(AtkUnitBase* atkUnitBase, NumberArrayData** nums, StringArrayData** strings) {
@@ -36,8 +42,21 @@ public class Hooks : IDisposable {
         return ret;
     }
 
+    private unsafe bool AgentItemDetailOnItemHoveredDetour(void* a1, void* a2, void* a3, void* a4, uint a5, uint a6, int* a7) {
+        var ret = agentItemDetailOnItemHovered.Original(a1, a2, a3, a4, a5, a6, a7);
+        try {
+            plugin.ItemPriceTooltip.LastItemQuantity = a7[3];
+        } catch (Exception e) {
+            plugin.ItemPriceTooltip.LastItemQuantity = null;
+            PluginLog.Log(e , "Failed to read last item quantity");
+        }
+
+        return ret;
+    }
+
     public void Dispose() {
         itemDetailOnUpdateHook.Dispose();
+        agentItemDetailOnItemHovered.Disable();
     }
 
 }

--- a/ItemPriceTooltip.cs
+++ b/ItemPriceTooltip.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Dalamud.Game.ClientState.Keys;
 using Dalamud.Game.Text.SeStringHandling;
@@ -42,14 +43,14 @@ public partial class ItemPriceTooltip : IDisposable {
         }
     }
 
-    [GeneratedRegex("(\\d+)\\/\\d+ \\(Total: \\d+", RegexOptions.Compiled)]
+    [GeneratedRegex(@"([\d,.]+)\/[\d,.]+ \(Total: \d", RegexOptions.Compiled)]
     private static partial Regex TooltipStackRegex();
 
     public unsafe int GetTooltipStackSize(AtkUnitBase* itemTooltip) {
         var stackSizeNode = itemTooltip->GetTextNodeById(33);
         var text = stackSizeNode->NodeText.ToString();
         var match = TooltipStackRegex().Match(text);
-        return match.Success ? int.Parse(match.Groups[1].Value) : 1;
+        return match.Success ? int.Parse(match.Groups[1].Value, NumberStyles.AllowThousands) : 1;
     }
 
     public unsafe void OnItemTooltip(AtkUnitBase* itemTooltip) {

--- a/ItemPriceTooltip.cs
+++ b/ItemPriceTooltip.cs
@@ -42,7 +42,7 @@ public partial class ItemPriceTooltip : IDisposable {
         }
     }
 
-    [GeneratedRegex("(\\d+)\\/\\d+ \\(Total: \\d+\\)", RegexOptions.Compiled)]
+    [GeneratedRegex("(\\d+)\\/\\d+ \\(Total: \\d+", RegexOptions.Compiled)]
     private static partial Regex TooltipStackRegex();
 
     public unsafe int GetTooltipStackSize(AtkUnitBase* itemTooltip) {

--- a/ItemPriceTooltip.cs
+++ b/ItemPriceTooltip.cs
@@ -163,7 +163,7 @@ public partial class ItemPriceTooltip : IDisposable {
                     if (!hq)
                         payloads.Add(new UIForegroundPayload(506));
                     payloads.Add(new TextPayload($"{nqPrice.Value.ToString(format, null)}{(withGilIcon ? GilIcon : "")}"));
-                    if (plugin.Configuration.ShowStackSalePrice && stackSize > 1)
+                    if (plugin.Configuration.ShowStackSalePrice && !hq && stackSize > 1)
                         payloads.Add(new TextPayload($" ({(nqPrice.Value * stackSize).ToString(format, null)}{(withGilIcon ? GilIcon : "")})"));
                     if (!hq)
                         payloads.Add(new UIForegroundPayload(0));
@@ -175,7 +175,7 @@ public partial class ItemPriceTooltip : IDisposable {
                     if (hq)
                         payloads.Add(new UIForegroundPayload(506));
                     payloads.Add(new TextPayload($"{HQIcon}{hqPrice.Value.ToString(format, null)}{(withGilIcon ? GilIcon : "")}"));
-                    if (plugin.Configuration.ShowStackSalePrice && stackSize > 1)
+                    if (plugin.Configuration.ShowStackSalePrice && hq && stackSize > 1)
                         payloads.Add(new TextPayload($" ({(hqPrice.Value * stackSize).ToString(format, null)}{(withGilIcon ? GilIcon : "")})"));
                     if (hq)
                         payloads.Add(new UIForegroundPayload(0));


### PR DESCRIPTION
While cleaning out my inventory, I often have the issue of wondering if it's worth the effort of putting the item on the market board. This option does the quick napkin math to show you how much the stack you are hovering over is worth if you were to put up your stack at that price. Suggestions are suggested; I'm not too sure of the wording still.

The item stack size is taken from tooltip text via regex. I'm not sure if there's a built-in into Dalamud way of finding it, outside of memory signatures or an InventoryTools dependency.

Configuration option:
![Configuration Window](https://github.com/Kouzukii/ffxiv-priceinsight/assets/16126912/293c9783-f8bb-4fed-8f23-5dcbc6d887f0)

Hovered example:
![Hovered Item Example](https://github.com/Kouzukii/ffxiv-priceinsight/assets/16126912/c71a95b4-df75-4700-897e-c6ce09278e65)
